### PR TITLE
Update to use latest version of go glint to fix windows plugin issues…

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,23 +91,23 @@ For full walkthough for creating a Waypoint Plugin and reference documentation, 
 Please see the following Plugins for examples of real world implementations of the Waypoint SDK.
 
 ### Build
-[Docker](https://github.com/hashicorp/waypoint/tree/main/builtin/docker/builder.go)
+[Docker](https://github.com/hashicorp/waypoint/tree/main/builtin/docker/builder.go)  
 [Build Packs](https://github.com/hashicorp/waypoint/tree/main/builtin/pack/builder.go)
 
 ### Registry
-[Docker](https://github.com/hashicorp/waypoint/tree/main/builtin/docker/registry.go)
+[Docker](https://github.com/hashicorp/waypoint/tree/main/builtin/docker/registry.go)  
 [Files](https://github.com/hashicorp/waypoint/tree/main/builtin/files/registry.go)
 
 ### Deploy
-[Nomad](https://github.com/hashicorp/waypoint/tree/main/builtin/nomad/platform.go)
-[Kubernetes](https://github.com/hashicorp/waypoint/tree/main/builtin/k8s/platform.go)
-[Docker](https://github.com/hashicorp/waypoint/tree/main/builtin/docker/platform.go)
-[Azure Container Interface](https://github.com/hashicorp/waypoint/tree/main/builtin/azure/aci/platform.go)
-[Google Cloud Run](https://github.com/hashicorp/waypoint/tree/main/builtin/google/cloudrun/platform.go)
-[Netlify](https://github.com/hashicorp/waypoint/tree/main/builtin/netlify/platform.go)
+[Nomad](https://github.com/hashicorp/waypoint/tree/main/builtin/nomad/platform.go)  
+[Kubernetes](https://github.com/hashicorp/waypoint/tree/main/builtin/k8s/platform.go)  
+[Docker](https://github.com/hashicorp/waypoint/tree/main/builtin/docker/platform.go)  
+[Azure Container Interface](https://github.com/hashicorp/waypoint/tree/main/builtin/azure/aci/platform.go)  
+[Google Cloud Run](https://github.com/hashicorp/waypoint/tree/main/builtin/google/cloudrun/platform.go)  
+[Netlify](https://github.com/hashicorp/waypoint/tree/main/builtin/netlify/platform.go)  
 [Amazon EC2](https://github.com/hashicorp/waypoint/tree/main/builtin/aws/ec2/platform.go)
 
 ### Release
-[Kubernetes](https://github.com/hashicorp/waypoint/tree/main/builtin/k8s/releaser.go)
-[Google Cloud Run](https://github.com/hashicorp/waypoint/tree/main/builtin/google/cloudrun/releaser.go)
+[Kubernetes](https://github.com/hashicorp/waypoint/tree/main/builtin/k8s/releaser.go)  
+[Google Cloud Run](https://github.com/hashicorp/waypoint/tree/main/builtin/google/cloudrun/releaser.go)  
 [Amazon ALB](https://github.com/hashicorp/waypoint/tree/main/builtin/aws/alb/releaser.go)

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/lab47/vterm v0.0.0-20201001232628-a9dd795f94c2
 	github.com/mattn/go-colorable v0.1.8
 	github.com/mattn/go-isatty v0.0.12
-	github.com/mitchellh/go-glint v0.0.0-20200930000256-df5e721f3258
+  github.com/mitchellh/go-glint v0.0.0-20201015034436-f80573c636de
 	github.com/mitchellh/go-testing-interface v1.14.1
 	github.com/mitchellh/mapstructure v1.3.3
 	github.com/mitchellh/protostructure v0.0.0-20200814180458-3cfccdb015ce


### PR DESCRIPTION
This PR updates the module `go-glint` to the latest version, this fixes issues when trying to build Waypoint plugins for Windows.

```shell
GOOS=linux GOARCH=amd64 go build -o ./bin/linux_amd64/waypoint-plugin-template ./main.go 
go: found github.com/hashicorp/waypoint-plugin-sdk in github.com/hashicorp/waypoint-plugin-sdk v0.0.0-00010101000000-000000000000
GOOS=darwin GOARCH=amd64 go build -o ./bin/darwin_amd64/waypoint-plugin-template ./main.go 
GOOS=windows GOARCH=amd64 go build -o ./bin/windows_amd64/waypoint-plugin-template.exe ./main.go 
# github.com/hashicorp/waypoint-plugin-sdk/terminal
../../waypoint-plugin-sdk/terminal/basic.go:34:14: undefined: pty.GetsizeFull
../../waypoint-plugin-sdk/terminal/display.go:61:19: undefined: pty.Getsize
Makefile:24: recipe for target 'build' failed
make: *** [build] Error 2
```