### PR TITLE
Force the UI stream to wait until the stream flushes

### DIFF
--- a/internal/plugin/terminal/ui.go
+++ b/internal/plugin/terminal/ui.go
@@ -268,6 +268,10 @@ func (u *uiBridge) Close() error {
 	defer u.mu.Unlock()
 
 	err := u.evc.CloseSend()
+
+	// So see an EOF on the other side
+	u.evc.Recv()
+
 	u.evc = nil
 	u.cancel()
 

--- a/internal/plugin/terminal/ui.go
+++ b/internal/plugin/terminal/ui.go
@@ -269,7 +269,10 @@ func (u *uiBridge) Close() error {
 
 	err := u.evc.CloseSend()
 
-	// So see an EOF on the other side
+	// The remote side never sends anything back to us, so this will just wait
+	// until the remote side has seen our closure and the stream has been
+	// closed. We don't actually care if there is an error here, just that
+	// we did wait.
 	u.evc.Recv()
 
 	u.evc = nil


### PR DESCRIPTION
We need to be sure that the plugin side of the UI observes the core side seeing all the events, otherwise the core side can exit (because the plugin function itself has returned) before the plugin side UI messages reach the core side. This results in missing UI events.

