### PR TITLE
nix: upgrade go version

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -6,15 +6,8 @@ let
   # the official nixpkgs repo.
   pkgs = import pkgsPath {
     overlays = [(self: super: {
-
-      go = super.go_1_14.overrideAttrs ( old: rec {
-        version = "1.14.5";
-        src = super.fetchurl {
-          url = "https://dl.google.com/go/go${version}.src.tar.gz";
-          sha256 = "0p1i80j3dk597ph5h6mvvv8p7rbzwmxdfb6558amcpkkj060hk6a";
-        };
-      });
-
+      go = super.go_1_16;
+      buildGoModule = super.buildGo116Module;
     })];
   };
 in with pkgs; let
@@ -52,20 +45,25 @@ in with pkgs; let
 
   go-tools = buildGoModule rec {
     pname = "go-tools";
-    version = "57a9e4404bf7b38f22bbca9af3ddf0dee8e76a04";
+    version = "35839b7038afa36a6c000733552daa1f5ce1e838";
 
     src = fetchFromGitHub {
       owner = "golang";
       repo = "tools";
-      rev = "57a9e4404bf7b38f22bbca9af3ddf0dee8e76a04";
-      sha256 = "1zih0v855vkr5j1rvahbbfd1w7rjf5rrgm20ra0b34nw7656x88h";
+      rev = "35839b7038afa36a6c000733552daa1f5ce1e838";
+      sha256 = "1gnqf62s7arqk807gadp4rd2diz1g0v2khwv9wsb50y8k9k4dfqs";
     };
 
     modSha256 = "1pijbkp7a9n2naicg21ydii6xc0g4jm5bw42lljwaks7211ag8k9";
-    vendorSha256 = "0pplmqxrnc8qnr5708igx4dm7rb0hicvhg6lh5hj8zkx38nb19s0";
+    vendorSha256 = "0i2fhaj2fd8ii4av1qx87wjkngip9vih8v3i9yr3h28hkq68zkm5";
 
     subPackages = [ "cmd/stringer" ];
+
+    # This has to be enabled because the stringer tests recompile itself
+    # so it needs a valid reference to `go`
+    allowGoReference = true;
   };
+
 
   go-mockery = buildGoModule rec {
     pname = "go-mockery";


### PR DESCRIPTION
Nix is still using Go 1.14 (Waypoint is using 1.16) and this is marked as insecure now:

```
error: Package ‘go-1.14.5’ in /nix/store/p3wcfqzy3bpl1bivq9bw8lid59hsrir5-nixpkgs-21.11pre292257.3847a2a8595/nixpkgs/pkgs/development/compilers/go/1.14.nix:264 is marked as insecure, refusing to evaluate.


Known issues:
 - Support for Go 1.14 ended with the release of Go 1.16: https://golang.org/doc/devel/release.html#policy

You can install it anyway by allowing this package, using the
following methods:
```

This PR changes the version to 1.16 and updates go-tools (copied from hashicorp/waypoint)