### PR TITLE
Integrate Status Reports into Resource Manager

### DIFF
--- a/framework/resource/manager.go
+++ b/framework/resource/manager.go
@@ -389,7 +389,7 @@ func (m *Manager) StatusAll(args ...interface{}) ([]*pb.StatusReport_Resource, e
 	var reports []*pb.StatusReport_Resource
 	for _, r := range m.resources {
 		if st := r.Status(); st != nil {
-			reports = append(reports, st.Reports...)
+			reports = append(reports, st.Resources...)
 		}
 	}
 	return reports, nil

--- a/framework/resource/manager.go
+++ b/framework/resource/manager.go
@@ -389,7 +389,7 @@ func (m *Manager) StatusAll(args ...interface{}) ([]*pb.StatusReport_Resource, e
 	var reports []*pb.StatusReport_Resource
 	for _, r := range m.resources {
 		if st := r.Status(); st != nil {
-			reports = append(reports, st)
+			reports = append(reports, st.Reports...)
 		}
 	}
 	return reports, nil

--- a/framework/resource/manager_test.go
+++ b/framework/resource/manager_test.go
@@ -324,7 +324,6 @@ func TestStatus_Manager(t *testing.T) {
 					return nil
 				}),
 				WithStatus(func(s *testState, sr *StatusResponse) error {
-					// WithStatus(func(s *testState, sr *pb.StatusReport_Resource) error {
 					rr := &pb.StatusReport_Resource{
 						Name: fmt.Sprintf(statusNameTpl, s.Value),
 					}
@@ -360,7 +359,12 @@ func TestStatus_Manager(t *testing.T) {
 					rr := &pb.StatusReport_Resource{
 						Name: fmt.Sprintf(statusNameTpl, s.Value),
 					}
-					sr.Reports = append(sr.Reports, rr)
+					// make sure we can return more than 1 StatusReport_Resource
+					// in a single Resource Status method
+					rr2 := &pb.StatusReport_Resource{
+						Name: fmt.Sprintf(statusNameTpl, s.Value+1),
+					}
+					sr.Reports = append(sr.Reports, rr, rr2)
 					return nil
 				}),
 			)),
@@ -383,12 +387,13 @@ func TestStatus_Manager(t *testing.T) {
 	reports, err := m.StatusAll()
 	require.NoError(err)
 
-	require.Len(reports, 3)
+	require.Len(reports, 4)
 	sort.Sort(byName(reports))
 
 	require.Equal("no state here", reports[0].Name)
 	require.Equal(fmt.Sprintf(statusNameTpl, 13), reports[1].Name)
-	require.Equal(fmt.Sprintf(statusNameTpl, 42), reports[2].Name)
+	require.Equal(fmt.Sprintf(statusNameTpl, 14), reports[2].Name)
+	require.Equal(fmt.Sprintf(statusNameTpl, 42), reports[3].Name)
 
 	// Destroy
 	require.NoError(m.DestroyAll())

--- a/framework/resource/manager_test.go
+++ b/framework/resource/manager_test.go
@@ -327,7 +327,7 @@ func TestStatus_Manager(t *testing.T) {
 					rr := &pb.StatusReport_Resource{
 						Name: fmt.Sprintf(statusNameTpl, s.Value),
 					}
-					sr.Reports = append(sr.Reports, rr)
+					sr.Resources = append(sr.Resources, rr)
 					return nil
 				}),
 			)),
@@ -343,7 +343,7 @@ func TestStatus_Manager(t *testing.T) {
 					rr := &pb.StatusReport_Resource{
 						Name: "no state here",
 					}
-					sr.Reports = append(sr.Reports, rr)
+					sr.Resources = append(sr.Resources, rr)
 					return nil
 				}),
 			)),
@@ -365,7 +365,7 @@ func TestStatus_Manager(t *testing.T) {
 					rr2 := &pb.StatusReport_Resource{
 						Name: fmt.Sprintf(statusNameTpl, s.Value+1),
 					}
-					sr.Reports = append(sr.Reports, rr, rr2)
+					sr.Resources = append(sr.Resources, rr, rr2)
 					return nil
 				}),
 			)),
@@ -427,7 +427,7 @@ func TestStatus_Manager_LoopRepro(t *testing.T) {
 					rr2 := &pb.StatusReport_Resource{
 						Name: fmt.Sprintf(statusNameTpl, s.Value+1),
 					}
-					sr.Reports = append(sr.Reports, rr, rr2)
+					sr.Resources = append(sr.Resources, rr, rr2)
 					return nil
 				}),
 			)),

--- a/framework/resource/manager_test.go
+++ b/framework/resource/manager_test.go
@@ -323,8 +323,12 @@ func TestStatus_Manager(t *testing.T) {
 					s.Value = v
 					return nil
 				}),
-				WithStatus(func(s *testState, sr *pb.StatusReport_Resource) error {
-					sr.Name = fmt.Sprintf(statusNameTpl, s.Value)
+				WithStatus(func(s *testState, sr *StatusResponse) error {
+					// WithStatus(func(s *testState, sr *pb.StatusReport_Resource) error {
+					rr := &pb.StatusReport_Resource{
+						Name: fmt.Sprintf(statusNameTpl, s.Value),
+					}
+					sr.Reports = append(sr.Reports, rr)
 					return nil
 				}),
 			)),
@@ -336,8 +340,11 @@ func TestStatus_Manager(t *testing.T) {
 					// no-op
 					return nil
 				}),
-				WithStatus(func(sr *pb.StatusReport_Resource) error {
-					sr.Name = "no state here"
+				WithStatus(func(sr *StatusResponse) error {
+					rr := &pb.StatusReport_Resource{
+						Name: "no state here",
+					}
+					sr.Reports = append(sr.Reports, rr)
 					return nil
 				}),
 			)),
@@ -349,8 +356,11 @@ func TestStatus_Manager(t *testing.T) {
 					s.Value = v
 					return nil
 				}),
-				WithStatus(func(s *testState2, sr *pb.StatusReport_Resource) error {
-					sr.Name = fmt.Sprintf(statusNameTpl, s.Value)
+				WithStatus(func(s *testState2, sr *StatusResponse) error {
+					rr := &pb.StatusReport_Resource{
+						Name: fmt.Sprintf(statusNameTpl, s.Value),
+					}
+					sr.Reports = append(sr.Reports, rr)
 					return nil
 				}),
 			)),

--- a/framework/resource/resource.go
+++ b/framework/resource/resource.go
@@ -192,8 +192,8 @@ func (r *Resource) DeclaredResource() (*pb.DeclaredResource, error) {
 	}, nil
 }
 
-// Status returns a copy of this resources' internal statusReports, or nil if no
-// status exists.
+// Status returns a copy of this resources' internal status response, or nil if
+// no status exists.
 func (r *Resource) Status() *StatusResponse {
 	if r.statusResp == nil {
 		return nil
@@ -205,9 +205,8 @@ func (r *Resource) Status() *StatusResponse {
 	}
 }
 
-// status is a method used to populate a Resources' statusReports. It is used
-// for testing purposes and should otherwise not be called directly at this
-// time.
+// status is a method used to populate a Resources' statusResp. At this time it
+// is used for testing purposes and should otherwise not be called directly.
 func (r *Resource) status(args ...interface{}) error {
 	if err := r.Validate(); err != nil {
 		return err

--- a/framework/resource/resource.go
+++ b/framework/resource/resource.go
@@ -631,3 +631,5 @@ func markerValue(n string) argmapper.Value {
 		Value:   reflect.ValueOf(val),
 	}
 }
+
+var statusResponseType = reflect.TypeOf((*StatusResponse)(nil))

--- a/framework/resource/resource.go
+++ b/framework/resource/resource.go
@@ -337,9 +337,6 @@ func (r *Resource) mapperForStatus() (*argmapper.Func, error) {
 	markerVal := markerValue(r.name)
 	outputs, err := argmapper.NewValueSet([]argmapper.Value{
 		markerVal,
-		{
-			Type: reflect.TypeOf(r.statusResp),
-		},
 	})
 	if err != nil {
 		return nil, err

--- a/framework/resource/resource.go
+++ b/framework/resource/resource.go
@@ -51,7 +51,7 @@ type Resource struct {
 // resource returning a single status containing a StatusReport_Resource for
 // each pod it currently tracks
 type StatusResponse struct {
-	Reports []*pb.StatusReport_Resource
+	Resources []*pb.StatusReport_Resource
 }
 
 // NewResource creates a new resource.
@@ -198,10 +198,10 @@ func (r *Resource) Status() *StatusResponse {
 	if r.statusResp == nil {
 		return nil
 	}
-	cp := make([]*pb.StatusReport_Resource, len(r.statusResp.Reports))
-	copy(cp, r.statusResp.Reports)
+	cp := make([]*pb.StatusReport_Resource, len(r.statusResp.Resources))
+	copy(cp, r.statusResp.Resources)
 	return &StatusResponse{
-		Reports: cp,
+		Resources: cp,
 	}
 }
 

--- a/framework/resource/resource.go
+++ b/framework/resource/resource.go
@@ -342,8 +342,24 @@ func (r *Resource) mapperForStatus() (*argmapper.Func, error) {
 		return nil, err
 	}
 
-	// Our inputs default to whatever the function requires
-	inputs, err := argmapper.NewValueSet(original.Input().Values())
+	// For input, we have to remove the status response type because
+	// we don't need it to call the func we build below because we'll
+	// construct it within the buildfunc call.
+	inputVals := original.Input().Values()
+	for i := 0; i < len(inputVals); i++ {
+		v := inputVals[i]
+		if v.Type != statusResponseType {
+			continue
+		}
+
+		// the type IS our status response type, we need to remove it. We do
+		// this by swapping with the last element (order doesn't matter)
+		// and decrementing i so we reloop over this value.
+		inputVals[len(inputVals)-1], inputVals[i] = inputVals[i], inputVals[len(inputVals)-1]
+		inputVals = inputVals[:len(inputVals)-1]
+		i--
+	}
+	inputs, err := argmapper.NewValueSet(inputVals)
 	if err != nil {
 		return nil, err
 	}

--- a/framework/resource/resource_test.go
+++ b/framework/resource/resource_test.go
@@ -165,7 +165,6 @@ func TestStatus_Resource(t *testing.T) {
 			return nil
 		}),
 		WithStatus(func(state *testState, sr *StatusResponse) error {
-			// WithStatus(func(state *testState, sr *pb.StatusReport_Resource) error {
 			rr := &pb.StatusReport_Resource{
 				Name:          fmt.Sprintf(statusNameTpl, state.Value),
 				Health:        pb.StatusReport_ALIVE,

--- a/framework/resource/resource_test.go
+++ b/framework/resource/resource_test.go
@@ -170,7 +170,7 @@ func TestStatus_Resource(t *testing.T) {
 				Health:        pb.StatusReport_ALIVE,
 				HealthMessage: fmt.Sprintf(healthMessageTpl, state.Value),
 			}
-			sr.Reports = append(sr.Reports, rr)
+			sr.Resources = append(sr.Resources, rr)
 			return nil
 		}),
 		WithDestroy(func(state *testState) error {
@@ -189,9 +189,9 @@ func TestStatus_Resource(t *testing.T) {
 	require.NoError(r.status(state, &StatusResponse{}))
 	require.NotNil(r.statusResp)
 
-	require.Equal(fmt.Sprintf(statusNameTpl, state.Value), r.statusResp.Reports[0].Name)
-	require.Equal(pb.StatusReport_ALIVE, r.statusResp.Reports[0].Health)
-	require.Equal(fmt.Sprintf(healthMessageTpl, state.Value), r.statusResp.Reports[0].HealthMessage)
+	require.Equal(fmt.Sprintf(statusNameTpl, state.Value), r.statusResp.Resources[0].Name)
+	require.Equal(pb.StatusReport_ALIVE, r.statusResp.Resources[0].Health)
+	require.Equal(fmt.Sprintf(healthMessageTpl, state.Value), r.statusResp.Resources[0].HealthMessage)
 
 	// Destroy
 	require.NoError(r.Destroy())


### PR DESCRIPTION
This PR add new parameters and methods to the Resource type for capturing a resources' status. The objective is to enable an easier way to collect status information on the resources created when trying to create a status report (ex. [k8s releaser.go][k8s]). 

Usage is predicated on the releaser/deployer et. al. already using the resource manager to manage creation/deletion of resources. 

Resource changes:

- `statusFunc` holds a function authors use to query the status of a resource and store the results in a new type `StatusResponse`, which contains a slice of [`[]*pb.StatusReport_Resource`][pbsrr] 
- `statusResp ` hold the actual `*StatusResponse` value
- `Status()` returns the current `statusResp` value, or `nil`

Resource Manager changes:

- `StatusAll()` method that creates argmapper function for every known resources' `statusFunc` method and returns a slice of the current status reports per known resource.

[k8s]: https://github.com/hashicorp/waypoint/blob/f956ed9cd09d4d739235f96dfbdbe135536c2497/builtin/k8s/releaser.go#L280
[pbsrr]: https://github.com/hashicorp/waypoint-plugin-sdk/blob/0bb01aa6da1297fc374f38fc07093bf53e4af983/proto/gen/plugin.pb.go#L2832