### PR TITLE
New exported constructor for basic ui

### DIFF
--- a/terminal/basic.go
+++ b/terminal/basic.go
@@ -23,6 +23,12 @@ type basicUI struct {
 	status *spinnerStatus
 }
 
+func NewBasicUI(ctx context.Context) *basicUI {
+	return &basicUI{
+		ctx: ctx,
+	}
+}
+
 // Returns a UI which will write to the current processes
 // stdout/stderr.
 func ConsoleUI(ctx context.Context) UI {


### PR DESCRIPTION
Hey Waypoint folks! I'm Nitya from the Consul-Kubernetes team. I'm working on a CLI for Consul-Kubernetes.

I had made this small change to my fork to export a constructor for the basicUI, and was able to use it for all our UI output related cases in the new consul-k8s-cli, and it worked great! I had previously made an attempt to use the Glint-based UI from this package, but we had needed the Input implementation for user input. I was wondering if you'd be open to merging this, or if you had any hesitations with exposing the basic ui. Also, if you're not looking to expose the basic ui directly here, would you have concerns with us copying some parts of the terminal/ui package into our own codebase? 

Here's a [branch of the integration](https://github.com/hashicorp/consul-k8s-cli/tree/waypoint-terminal-ui) in our CLI for context on how nice it was to use! (I gave the @ waypoint team read access)