### PR TITLE
terminal/table: Add simple table formatter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
           fingerprints:
             - "c6:96:98:82:dc:04:6c:39:dd:ac:83:05:e3:15:1c:98"
       - protobuf/install:
-          version: 3.0.0
+          version: 3.15.8
       - checkout
       - attach_workspace:
           at: /go/bin

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PROTOC_VERSION="3.15.8"
 .PHONY: gen
 gen: # generate go code
 	@# Test for correct version of protoc
-	@if [[ "$(shell protoc --version | awk '{print $$2}')" != $(PROTOC_VERSION) ]]; then \
+	@if [ "$(shell protoc --version | awk '{print $$2}')" != $(PROTOC_VERSION) ]; then \
   		echo "Incorrect version of protoc installed. $(shell protoc --version | awk '{print $2}') detected, $(PROTOC_VERSION) required."; \
   		echo "You can install the correct version from https://github.com/protocolbuffers/protobuf/releases/tag/v$(PROTOC_VERSION) or consider using nix."; \
   		exit 1; \
@@ -29,7 +29,7 @@ tools: # install dependencies and tools required to build
 	@test -s "thirdparty/proto/api-common-protos/.git" || { echo "git submodules not initialized, run 'git submodule update --init --recursive' and try again"; exit 1; }
 
 	@# Test for protoc installed
-	@if [[ $(shell which protoc | wc -l) == 0 ]]; then \
+	@if [ $(shell which protoc | wc -l) == 0 ]; then \
 		echo "Required tool protoc not installed." \
 		echo "You can install the correct version from https://github.com/protocolbuffers/protobuf/releases/tag/v$(PROTOC_VERSION) or consider using nix."; \
 		exit 1; \

--- a/terminal/glint.go
+++ b/terminal/glint.go
@@ -165,11 +165,31 @@ func (ui *glintUI) StepGroup() StepGroup {
 
 // Table implements UI
 func (ui *glintUI) Table(tbl *Table, opts ...Option) {
+	// Build our config and set our options
+	cfg := &config{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
 	var buf bytes.Buffer
 	table := tablewriter.NewWriter(&buf)
 	table.SetHeader(tbl.Headers)
 	table.SetBorder(false)
 	table.SetAutoWrapText(false)
+
+	if cfg.Style == "Simple" {
+		// Format the table without borders, simple output
+
+		table.SetAutoFormatHeaders(true)
+		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+		table.SetAlignment(tablewriter.ALIGN_LEFT)
+		table.SetCenterSeparator("")
+		table.SetColumnSeparator("")
+		table.SetRowSeparator("")
+		table.SetHeaderLine(false)
+		table.SetTablePadding("\t") // pad with tabs
+		table.SetNoWhiteSpace(true)
+	}
 
 	for _, row := range tbl.Rows {
 		colors := make([]tablewriter.Colors, len(row))

--- a/terminal/noninteractive.go
+++ b/terminal/noninteractive.go
@@ -134,6 +134,20 @@ func (ui *nonInteractiveUI) Table(tbl *Table, opts ...Option) {
 	table.SetBorder(false)
 	table.SetAutoWrapText(false)
 
+	if cfg.Style == "Simple" {
+		// Format the table without borders, simple output
+
+		table.SetAutoFormatHeaders(true)
+		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+		table.SetAlignment(tablewriter.ALIGN_LEFT)
+		table.SetCenterSeparator("")
+		table.SetColumnSeparator("")
+		table.SetRowSeparator("")
+		table.SetHeaderLine(false)
+		table.SetTablePadding("\t") // pad with tabs
+		table.SetNoWhiteSpace(true)
+	}
+
 	for _, row := range tbl.Rows {
 		colors := make([]tablewriter.Colors, len(row))
 		entries := make([]string, len(row))

--- a/terminal/table.go
+++ b/terminal/table.go
@@ -48,9 +48,24 @@ func (u *basicUI) Table(tbl *Table, opts ...Option) {
 	}
 
 	table := tablewriter.NewWriter(cfg.Writer)
+
 	table.SetHeader(tbl.Headers)
 	table.SetBorder(false)
 	table.SetAutoWrapText(false)
+
+	if cfg.Style == "Simple" {
+		// Format the table without borders, simple output
+
+		table.SetAutoFormatHeaders(true)
+		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+		table.SetAlignment(tablewriter.ALIGN_LEFT)
+		table.SetCenterSeparator("")
+		table.SetColumnSeparator("")
+		table.SetRowSeparator("")
+		table.SetHeaderLine(false)
+		table.SetTablePadding("\t") // pad with tabs
+		table.SetNoWhiteSpace(true)
+	}
 
 	for _, row := range tbl.Rows {
 		colors := make([]tablewriter.Colors, len(row))


### PR DESCRIPTION
This commit adds a simple table formatter if the "Simple" option was
specified as a style when printing the table.

This PR also fixes a bash error in this projects Makefile. if-expressions should be single bracketed in a Makefile.
Makefiles use sh by default, not bash:

```
brian@localghost:waypoint-plugin-sdk λ make                                                                                                                                                                        ±[●][feat/simple-table-fmt]
/bin/sh: 1: [[: not found
```