### PR TITLE
Mappers and component for DeclaredResources

### DIFF
--- a/component/component.go
+++ b/component/component.go
@@ -10,7 +10,11 @@
 // framework (see internal/mapper) to call these functions.
 package component
 
-import proto "github.com/hashicorp/waypoint-plugin-sdk/proto/gen"
+import (
+	"fmt"
+
+	proto "github.com/hashicorp/waypoint-plugin-sdk/proto/gen"
+)
 
 //go:generate stringer -type=Type -linecomment
 //go:generate mockery -all -case underscore
@@ -317,6 +321,22 @@ type RunningTask interface{}
 // it's direct management.
 type DeclaredResources struct {
 	Resources []*proto.DeclaredResource
+}
+
+// ByName finds one DeclaredResource with a matching name.
+// Returns an error if multiple resources are found.
+// Returns a nil DeclaredResource if no match is found.
+func (d *DeclaredResources) ByName(name string) (*proto.DeclaredResource, error) {
+	var ret *proto.DeclaredResource
+	for _, dr := range d.Resources {
+		if dr.Name == name {
+			if ret != nil {
+				return nil, fmt.Errorf("multiple declared resources with name %s", name)
+			}
+			ret = dr
+		}
+	}
+	return ret, nil
 }
 
 // OutParameter is an argument type that is used by plugins as a vehicle for returning

--- a/component/component.go
+++ b/component/component.go
@@ -313,6 +313,12 @@ type Generation interface {
 // use later to stop the task.
 type RunningTask interface{}
 
+// DeclaredResources is a group of resources that a plugin had declared to be under
+// it's direct management.
+type DeclaredResources struct {
+	Resources []*proto.DeclaredResource
+}
+
 // OutParameter is an argument type that is used by plugins as a vehicle for returning
 // data to core. A struct implementing this interface that indicates to the plugin system
 // that the struct should not be included in a grpc advertised dynamic function spec, because

--- a/internal-shared/protomappers/mappers.go
+++ b/internal-shared/protomappers/mappers.go
@@ -34,6 +34,8 @@ var All = []interface{}{
 	DatadirProjectProto,
 	DatadirAppProto,
 	DatadirComponentProto,
+	DeclaredResourcesComponent,
+	DeclaredResourcesComponentProto,
 	Logger,
 	LoggerProto,
 	TerminalUI,
@@ -132,6 +134,17 @@ func DatadirComponentProto(input *datadir.Component) *pb.Args_DataDir_Component 
 		CacheDir: input.CacheDir(),
 		DataDir:  input.DataDir(),
 	}
+}
+
+// DeclaredResourcesComponent maps *pb.DeclaredResources to *component.DeclaredResources
+func DeclaredResourcesComponent(input *pb.DeclaredResources) (*component.DeclaredResources, error) {
+	var result component.DeclaredResources
+	return &result, mapstructure.Decode(input, &result)
+}
+
+func DeclaredResourcesComponentProto(input *component.DeclaredResources) (*pb.DeclaredResources, error) {
+	var result pb.DeclaredResources
+	return &result, mapstructure.Decode(input, &result)
 }
 
 // Logger maps *pb.Args_Logger to an hclog.Logger


### PR DESCRIPTION
Facilitates https://github.com/hashicorp/waypoint/pull/1970

This lays the groundwork for allowing DeclaredResources to be wired into plugin Status functions. The plugin status functions need Declared Resources so they can identify which Status Report resources are instantiations of which Declared Resources.