### PR TITLE
framework/resource: DestroyAll with manual SetState calls in reverse order

### DIFF
--- a/framework/resource/manager_test.go
+++ b/framework/resource/manager_test.go
@@ -358,11 +358,8 @@ func TestManagerDestroyAll_loadState(t *testing.T) {
 	// Destroy
 	require.NoError(m.DestroyAll())
 
-	// Destroy order is non-deterministic for this case, so sort
-	sort.Strings(destroyOrder)
-
 	// Ensure we destroyed
-	require.Equal([]string{"A", "B"}, destroyOrder)
+	require.Equal([]string{"B", "A"}, destroyOrder)
 	require.Equal(destroyState, int32(42))
 }
 


### PR DESCRIPTION
The order is determined by the order the SetState is called, as recommend by @catsby.

This is a bit hacky and a bit magic but as @catsby pointed out, this is a legacy API to support old usage that we can probably remove in the future, so if its hacky for now its probably fine.