### PR TITLE
New `StatusReport` function on resource manager

### DIFF
--- a/framework/resource/manager.go
+++ b/framework/resource/manager.go
@@ -384,7 +384,7 @@ func healthSummary(resources []*pb.StatusReport_Resource) (
 	// We want to generate healths in a deterministic order. To do that,
 	// we need to pull out the map keys, sort them, and access by those in order.
 	var distinctHealths []int
-	for k, _ := range countByHealthByResourceType {
+	for k := range countByHealthByResourceType {
 		distinctHealths = append(distinctHealths, k)
 	}
 
@@ -402,7 +402,7 @@ func healthSummary(resources []*pb.StatusReport_Resource) (
 		countByResourceType := countByHealthByResourceType[healthStatus]
 
 		var distinctResourceTypes []string
-		for k, _ := range countByResourceType {
+		for k := range countByResourceType {
 			distinctResourceTypes = append(distinctResourceTypes, k)
 		}
 		sort.Strings(distinctResourceTypes)

--- a/framework/resource/resource.go
+++ b/framework/resource/resource.go
@@ -388,6 +388,26 @@ func (r *Resource) mapperForStatus() (*argmapper.Func, error) {
 		// Call our function. We throw away any result types except for the
 		// error.
 		result := original.Call(args...)
+
+		// Fill in default values where we can
+		if r.statusResp != nil {
+			for _, resource := range r.statusResp.Resources {
+				if resource == nil {
+					continue
+				}
+				// Default values to the parent resource type where possible
+				if resource.Name == "" {
+					resource.Name = r.name
+				}
+				if resource.Type == "" {
+					resource.Type = r.resourceType
+				}
+				if resource.Platform == "" {
+					resource.Platform = r.platform
+				}
+			}
+		}
+
 		return result.Err()
 	}, argmapper.FuncOnce())
 }

--- a/proto/gen/plugin.pb.go
+++ b/proto/gen/plugin.pb.go
@@ -3142,10 +3142,13 @@ type StatusReport_Resource struct {
 	// Resources that created this resource.
 	ParentResourceId string `protobuf:"bytes,6,opt,name=parent_resource_id,json=parentResourceId,proto3" json:"parent_resource_id,omitempty"`
 	// Friendly name of the resource, if applicable
+	// If using resource manager, this will default to the name of the resource manager resource
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// The platform on which the resource exists.
+	// If using resource manager, this will default to the platform of the resource manager resource
 	Platform string `protobuf:"bytes,7,opt,name=platform,proto3" json:"platform,omitempty"`
 	// platform-specific name of the resource type. i.e. instance, pod, auto-scaling group, etc
+	// If using resource manager, this will default to the type of the resource manager resource
 	Type string `protobuf:"bytes,8,opt,name=type,proto3" json:"type,omitempty"`
 	// A link directly to the resource in the platform, if applicable.
 	PlatformUrl string `protobuf:"bytes,9,opt,name=platform_url,json=platformUrl,proto3" json:"platform_url,omitempty"`

--- a/proto/plugin.proto
+++ b/proto/plugin.proto
@@ -377,12 +377,15 @@ message StatusReport {
     string parent_resource_id = 6;
 
     // Friendly name of the resource, if applicable
+    // If using resource manager, this will default to the name of the resource manager resource
     string name = 1;
 
     // The platform on which the resource exists.
+    // If using resource manager, this will default to the platform of the resource manager resource
     string platform = 7;
 
     // platform-specific name of the resource type. i.e. instance, pod, auto-scaling group, etc
+    // If using resource manager, this will default to the type of the resource manager resource
     string type = 8;
 
     // A link directly to the resource in the platform, if applicable.


### PR DESCRIPTION
Introduces a new resource manager function `StatusReport`, that behind the scenes calls `StatusAll`, and then builds a status report
containing all the resources returned by the plugin's status functions. It also takes a stab at determining the overall health given
the list of resources.

If all resources return the same health, the overall health will be that health. If resources return different healths, the overall
health will be PARTIAL, and the health message will give more details.

Incidentally, this also lets the `Name`, `Type`, and `Platform` values of status report resources default to the parent resource's values
if they are unset. They generally will the same as the parent resource, so this is a nice convenience for plugin devs.