### PR TITLE
Allowing hidden fields in docs

### DIFF
--- a/component/configure.go
+++ b/component/configure.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/waypoint-plugin-sdk/docs"
 )
 
-// Configurable can be optionally implemented by any compontent to
+// Configurable can be optionally implemented by any component to
 // accept user configuration.
 type Configurable interface {
 	// Config should return a pointer to an allocated configuration
@@ -19,7 +19,7 @@ type Configurable interface {
 // Documented can be optionally implemented by any component to
 // return documentation about the component.
 type Documented interface {
-	// Documentation() returns a completed docs.Documentation struct
+	// Documentation returns a completed docs.Documentation struct
 	// describing the components configuration.
 	Documentation() (*docs.Documentation, error)
 }

--- a/docs/docs_test.go
+++ b/docs/docs_test.go
@@ -1,0 +1,29 @@
+package docs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHiddenDocsFields(t *testing.T) {
+	require := require.New(t)
+
+	type config struct {
+		normal     string `hcl:"normal"`
+		deprecated string `hcl:"deprecated" docs:"hidden"` // Hidden docs fields are invisible
+	}
+
+	expectedFields := map[string]*FieldDocs{
+		"normal": {
+			Field: "normal",
+			Type:  "string",
+		},
+	}
+
+	actualFields := make(map[string]*FieldDocs)
+
+	require.Nil(fromConfig(&config{}, actualFields))
+
+	require.Equal(expectedFields, actualFields)
+}


### PR DESCRIPTION
This introduces a new "docs" struct annotation with a "hidden" value that prevents fields from being returned in docs. This allows us to deprecate and "hide" fields, while still parsing them correctly, so we can give useful warnings or errors beyond hcl parse errors. See the test for an example.

This also introduces a new interface, "DocField", that allows the creation of anomyous doc field setters that can work on `Documentation` or `SubFieldDoc` structs. This will be used in an upcoming pr in core.

Also incidental typo fixes.