### PR TITLE
Fix subfield parsing logic.

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -335,6 +335,17 @@ func (s *SubFieldDoc) merge(m map[string]*FieldDocs) {
 	}
 }
 
+// Create sub-fields from existing subfield docs.
+func (s *SubFieldDoc) SubFields(parent string, f func(d *SubFieldDoc)) *SubFieldDoc {
+	sf := &SubFieldDoc{
+		fields: s.fields[parent].discoveredFields,
+	}
+
+	f(sf)
+
+	return sf
+}
+
 func (s *SubFieldDoc) SetField(name, synposis string, opts ...docOption) error {
 	field, ok := s.fields[name]
 	if !ok {
@@ -371,6 +382,7 @@ func (d *SubFieldDoc) Fields() []*FieldDocs {
 	return fields
 }
 
+// DEPRECATED - use the method SubField instead. This breaks if you next more than 1 layer deep.
 func SubFields(f func(d *SubFieldDoc)) *SubFieldDoc {
 	sf := &SubFieldDoc{
 		fields: make(map[string]*FieldDocs),
@@ -381,7 +393,17 @@ func SubFields(f func(d *SubFieldDoc)) *SubFieldDoc {
 	return sf
 }
 
-//
+// Create sub-fields from existing parent docs.
+func (d *Documentation) SubFields(parent string, f func(d *SubFieldDoc)) *SubFieldDoc {
+	sf := &SubFieldDoc{
+		fields: d.fields[parent].discoveredFields,
+	}
+
+	f(sf)
+
+	return sf
+}
+
 // SetField sets various documentation for the given field. If the field is already
 // known, the documentation is merely updated. If the field is missing, it is created.
 func (d *Documentation) SetField(name, synposis string, opts ...docOption) error {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -382,7 +382,7 @@ func (d *SubFieldDoc) Fields() []*FieldDocs {
 	return fields
 }
 
-// DEPRECATED - use the method SubField instead. This breaks if you next more than 1 layer deep.
+// DEPRECATED - use the method SubField instead. This breaks if you nest more than 1 layer deep.
 func SubFields(f func(d *SubFieldDoc)) *SubFieldDoc {
 	sf := &SubFieldDoc{
 		fields: make(map[string]*FieldDocs),


### PR DESCRIPTION
Fixes https://github.com/hashicorp/waypoint/issues/2464

To see this in action: https://github.com/hashicorp/waypoint/pull/2467

This one took me a while to wrap my head around.

The bug is that, if you have a sub-field inside a sub-field, that field won't have any type information. This is because the type information is discovered once, and lives on the parent `*Documentation` struct, and we weren't passing it along into the nested SubFields.

This is the most minimally-invasive fix I can think of. It leaves the old codepath, which works for 99% of our plugin docs, but creates a new, similar-feeling function that works for deeply nested fields. We mentioned recently that we want to overhaul the docs generation soon to change style of our docs, so I think probably ok that this fix isn't beautiful or comprehensive.

I'll admit that I can only hold around 80% of this docs generation flow in my head at once today, so I may be leaving a better solution on the table. If anyone has a better idea, I'm all ears. 