### PR TITLE
Removing an errant error log

### DIFF
--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -298,8 +298,6 @@ func (s *registryServer) Access(
 
 	fn := ra.AccessInfoFunc()
 
-	s.Logger.Error("CALLING ACCESS", "target", hclog.Fmt("%T", ra), "fn", hclog.Fmt("%#v", fn))
-
 	internal := s.internal()
 	defer internal.Cleanup.Close()
 


### PR DESCRIPTION
This error log looks like this:

```
2022-03-18T14:00:15.015Z [ERROR] waypoint.runner.agent.runner.app.backend.registry.waypoint: CALLING ACCESS: job_id=01FYEN89ENANWTTVV1XN9Q6VJQ job_op=*gen.Job_Build @module=plugin fn="(func() (*docker.AccessInfo, error))(0x1401900)" target=*docker.Registry timestamp=2022-03-18T14:00:15.015Z

```

Which isn't useful for users, and is logged on every registry push. I think this was leftover from debugging.