### PR TITLE
Fix panic when destroying with no DestroyedResourceResponse

### DIFF
--- a/framework/resource/manager.go
+++ b/framework/resource/manager.go
@@ -363,7 +363,7 @@ func (m *Manager) DestroyAll(args ...interface{}) error {
 	// destroy function, then it is a declaredResource. If it does, it's a destroyedResource
 	if m.dcr != nil || m.dtr != nil {
 		for name, resource := range m.resources {
-			if resource.destroyFunc != nil {
+			if m.dtr != nil && resource.destroyFunc != nil {
 				destroyedResource, err := resource.DestroyedResource()
 				if err != nil {
 					m.logger.Debug("Failed to convert resource to a DestroyedResource proto message",
@@ -374,7 +374,7 @@ func (m *Manager) DestroyAll(args ...interface{}) error {
 				}
 
 				m.dtr.DestroyedResources = append(m.dtr.DestroyedResources, destroyedResource)
-			} else {
+			} else if m.dcr != nil && resource.createFunc != nil {
 				declaredResource, err := resource.DeclaredResource()
 				if err != nil {
 					m.logger.Debug("Failed to convert resource to a DeclaredResource proto message",


### PR DESCRIPTION
Steps to reproduce:

- Install a runner into a kubernetes cluster:
```
wp runner install -platform=kubernetes -server-addr=api.hashicorp.cloud:443 -id=dev -- -label=env=dev
```

- Attempt a `waypoint up`. There's currently an unrelated bug in `runner install` where the runner profile isn't using the right service account, so it can't hit the k8s api to list deployments. Here's what it looks like from the CLI:

```
$ wp up -workspace=dev
There are local changes that do not match the remote repository. By default,
Waypoint will perform this operation using a remote runner that will use the
remote repository’s git ref and not these local changes. For these changes
to be used for future operations, either commit and push, or run the operation
locally with the -local flag.

» Operation is queued waiting for job "01GD3B2Z5SA3QSRH8AZRZ47F3J". Waiting for runner assignment...
  If you interrupt this command, the job will still run in the background.
  Performing operation on "kubernetes" with runner profile "kubernetes-DEV"

» Cloning data from Git
  URL: https://github.com/hashicorp/waypoint-examples
  Ref: go-multicluster

» Building backend...

... <truncated for brevity> ...

✓ All services available.
✓ Set ECR Repository name to 'acmecorp'

» Deploying backend...
✓ Running deploy v1
✓ Kubernetes client connected to https://10.100.0.1:443 with namespace default
❌ Preparing deployment...
✓ Kubernetes client connected to https://10.100.0.1:443 with namespace default
❌ Deleting deployment...
! error reading from server: EOF

```

And the ODR logs:
```
...
2022-09-16T14:26:50.749Z [INFO]  waypoint.runner.agent.runner.app.backend.platform: platform plugin capable of auth: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.754Z [INFO]  waypoint.runner.agent.runner.app.backend.platform: platform plugin capable of status: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.755Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform: plugin successfully launched and connected: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.755Z [INFO]  waypoint.runner.agent.runner.app.backend.platform: initialized component: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up type=Platform
2022-09-16T14:26:50.759Z [DEBUG] waypoint.runner.agent.runner.app.backend: evaluating config vars for syncing: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.759Z [DEBUG] waypoint.runner.agent.runner.app.backend: no file-based config vars, not syncing config: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.796Z [INFO]  waypoint.runner.agent.runner.app.backend.platform.waypoint: error during creation, starting rollback: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up @module=waypoint.runner.agent.runner.app.backend.deploy.resource_manager err="deployments.apps "backend-v1" is forbidden: User "system:serviceaccount:default:default" cannot get resource "deployments" in API group "apps" in the namespace "default"" timestamp=2022-09-16T14:26:50.796Z
2022-09-16T14:26:50.800Z [INFO]  waypoint.runner.agent.runner.app.backend.platform.waypoint: error during destruction: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up @module=waypoint.runner.agent.runner.app.backend.deploy.resource_manager err="resource name may not be empty" timestamp=2022-09-16T14:26:50.800Z
2022-09-16T14:26:50.803Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: panic: runtime error: invalid memory address or nil pointer dereference: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.803Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xe7eac0]: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.803Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: : job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.803Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: goroutine 54 [running]:: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.803Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: github.com/hashicorp/waypoint-plugin-sdk/framework/resource.(*Manager).DestroyAll(0xc000957bd0, {0xc000c10e18, 0x8, 0xc0005c2d40}): job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.804Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: 	/go/pkg/mod/github.com/hashicorp/waypoint-plugin-sdk@v0.0.0-20220831214951-89c00954cebb/framework/resource/manager.go:376 +0x9a0: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.804Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: github.com/hashicorp/waypoint-plugin-sdk/framework/resource.(*Manager).CreateAll(0xc000957bd0, {0xc000c10e18, 0xc00075ea80, 0x8}): job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.804Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: 	/go/pkg/mod/github.com/hashicorp/waypoint-plugin-sdk@v0.0.0-20220831214951-89c00954cebb/framework/resource/manager.go:207 +0x61b: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.804Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: github.com/hashicorp/waypoint/builtin/k8s.(*Platform).Deploy(0x2, {0x3a9fd88, 0xc000a43f20}, {0x3b2ed10, 0xc00075ea80}, 0xc000757fc0, 0xc000c58d20, 0xc0003a78c0, 0xc000ccadc0, {0x7f42c577b458, ...}): job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.805Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: 	/tmp/wp-src/builtin/k8s/platform.go:1249 +0x36b: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.805Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: reflect.Value.call({0x2f19600, 0xc000d795f0, 0xc000533640}, {0x3380a51, 0x4}, {0xc000830f20, 0x7, 0x2fd2ae0}): job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.805Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: 	/usr/local/go/src/reflect/value.go:543 +0x814: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.806Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: reflect.Value.Call({0x2f19600, 0xc000d795f0, 0xc000957680}, {0xc000830f20, 0x7, 0x7}): job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.806Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: 	/usr/local/go/src/reflect/value.go:339 +0xc5: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.806Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: github.com/hashicorp/go-argmapper.(*Func).callDirect(0xc00090f920, {0x3b2ed10, 0xc0009d6980}, 0xc0009d6980): job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.806Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: 	/go/pkg/mod/github.com/hashicorp/go-argmapper@v0.2.4/call.go:598 +0x3dc: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.806Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: github.com/hashicorp/go-argmapper.(*Func).Call(0x2f19600, {0xc0009b7e00, 0x0, 0xc0006646e0}): job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.807Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: 	/go/pkg/mod/github.com/hashicorp/go-argmapper@v0.2.4/call.go:37 +0x1fb: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.807Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: github.com/hashicorp/waypoint-plugin-sdk/internal/plugin.callDynamicFunc2({0x2f19600, 0xc000d795f0}, {0xc0008e96c0, 0x5, 0xc000094400}, {0xc000c8fb50, 0x0, 0x10}): job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.807Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: 	/go/pkg/mod/github.com/hashicorp/waypoint-plugin-sdk@v0.0.0-20220831214951-89c00954cebb/internal/plugin/dynamic_call.go:91 +0x7c5: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.808Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: github.com/hashicorp/waypoint-plugin-sdk/internal/plugin.callDynamicFuncAny2({0x2f19600, 0xc000d795f0}, {0xc0008e96c0, 0x492, 0x492}, {0xc000c8fb50, 0xc0008e9680, 0xc000c8fb78}): job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.808Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: 	/go/pkg/mod/github.com/hashicorp/waypoint-plugin-sdk@v0.0.0-20220831214951-89c00954cebb/internal/plugin/dynamic_call.go:106 +0x4b: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.808Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: github.com/hashicorp/waypoint-plugin-sdk/internal/plugin.(*platformServer).Deploy(0xc000588600, {0x3a9fd88, 0xc000a43f20}, 0xc0008e9680): job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.808Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: 	/go/pkg/mod/github.com/hashicorp/waypoint-plugin-sdk@v0.0.0-20220831214951-89c00954cebb/internal/plugin/platform.go:441 +0x33c: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.809Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: github.com/hashicorp/waypoint-plugin-sdk/proto/gen._Platform_Deploy_Handler({0x32f5b60, 0xc000588600}, {0x3a9fd88, 0xc000a43f20}, 0xc00090f080, 0x0): job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.809Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: 	/go/pkg/mod/github.com/hashicorp/waypoint-plugin-sdk@v0.0.0-20220831214951-89c00954cebb/proto/gen/plugin_grpc.pb.go:1733 +0x170: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.809Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: google.golang.org/grpc.(*Server).processUnaryRPC(0xc000c9e1c0, {0x3afa070, 0xc000a75520}, 0xc0005f9c20, 0xc000cd2ab0, 0xae37358, 0x0): job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.809Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: 	/go/pkg/mod/google.golang.org/grpc@v1.45.0/server.go:1282 +0xccf: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.810Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: google.golang.org/grpc.(*Server).handleStream(0xc000c9e1c0, {0x3afa070, 0xc000a75520}, 0xc0005f9c20, 0x0): job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.810Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: 	/go/pkg/mod/google.golang.org/grpc@v1.45.0/server.go:1619 +0xa2a: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.810Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: google.golang.org/grpc.(*Server).serveStreams.func1.2(): job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.810Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: 	/go/pkg/mod/google.golang.org/grpc@v1.45.0/server.go:921 +0x98: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.810Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: created by google.golang.org/grpc.(*Server).serveStreams.func1: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.810Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.waypoint: 	/go/pkg/mod/google.golang.org/grpc@v1.45.0/server.go:919 +0x294: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.813Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform.stdio: received EOF, stopping recv loop: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up err="rpc error: code = Unavailable desc = error reading from server: EOF"
2022-09-16T14:26:50.814Z [WARN]  waypoint.runner.agent.runner.app.backend.deploy: error during local operation: id=01GD3B3WK9GY7350GW0K47N678 job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up err="rpc error: code = Unavailable desc = error reading from server: EOF"
2022-09-16T14:26:50.814Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform: plugin process exited: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up path=/kaniko/waypoint pid=125 error="exit status 2"
2022-09-16T14:26:50.862Z [DEBUG] waypoint.runner.agent.runner.app.backend.deploy: metadata marked as complete: id=01GD3B3WK9GY7350GW0K47N678 job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.862Z [DEBUG] waypoint.runner.agent.runner.app.backend.platform: plugin exited: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.862Z [DEBUG] waypoint.runner.agent.runner: closing project: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.863Z [DEBUG] waypoint.runner.agent.runner.app.backend.mapper.stdio: received EOF, stopping recv loop: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up err="rpc error: code = Unavailable desc = error reading from server: EOF"
2022-09-16T14:26:50.865Z [DEBUG] waypoint.runner.agent.runner.app.backend.mapper: plugin process exited: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up path=/kaniko/waypoint pid=27
2022-09-16T14:26:50.865Z [DEBUG] waypoint.runner.agent.runner.app.backend.mapper: plugin exited: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.865Z [DEBUG] waypoint.runner.agent.runner: cleaning up downloaded data: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up
2022-09-16T14:26:50.894Z [DEBUG] waypoint.runner.agent.runner: job finished: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up error="rpc error: code = Unavailable desc = error reading from server: EOF"
2022-09-16T14:26:50.894Z [WARN]  waypoint.runner.agent.runner: error during job execution: job_id=01GD3B2Z5SA3QSRH8AZRZ47F3J job_op=*gen.Job_Up err="rpc error: code = Unavailable desc = error reading from server: EOF"
2022-09-16T14:26:50.929Z [DEBUG] waypoint.runner.agent: handled our one job in ODR mode, exiting
2022-09-16T14:26:50.930Z [INFO]  waypoint.runner.agent: quit request received, gracefully stopping runner
2022-09-16T14:26:50.930Z [WARN]  waypoint.runner.agent.runner.config.watcher: exiting due to context ended
2022-09-16T14:26:50.930Z [WARN]  waypoint.runner.agent.runner.config_recv: EOF or cancellation received, graceful close of runner config stream
2022-09-16T14:26:50.930Z [WARN]  waypoint: context cancelled, stopping interrupt listener loop
```

## Root cause
The k8s platform doesn't request a destroyed resources response - only ECS does (here: https://github.com/hashicorp/waypoint/blob/b0b4dd43c42a610102015f45a827779e7facd065/builtin/aws/ecs/platform.go#L176). Its resources do have destroy functions though, so we were trying to add them to a nil `m.dct`.

## Testing

Here's the client's view with this fix in the on-demand runner: 

```
$ wp up -workspace=dev
There are local changes that do not match the remote repository. By default,
Waypoint will perform this operation using a remote runner that will use the
remote repository’s git ref and not these local changes. For these changes
to be used for future operations, either commit and push, or run the operation
locally with the -local flag.

» Operation is queued waiting for job "01GD3CJWM5ABKYZ9YRH0VMCNCZ". Waiting for runner assignment...
  If you interrupt this command, the job will still run in the background.
  Performing operation on "kubernetes" with runner profile "kubernetes-DEV"

» Cloning data from Git
  URL: https://github.com/hashicorp/waypoint-examples
  Ref: go-multicluster

» Downloading from Git

... <truncated> ...
✓ Running push build v2
✓ All services available.
✓ Set ECR Repository name to 'acmecorp'

» Deploying backend...
✓ Running deploy v2
✓ Kubernetes client connected to https://10.100.0.1:443 with namespace default
❌ Preparing deployment...
✓ Kubernetes client connected to https://10.100.0.1:443 with namespace default
❌ Deleting deployment...
! 2 errors occurred:
  	* deployments.apps "backend-v2" is forbidden: User
  "system:serviceaccount:default:default" cannot get resource "deployments" in API
  group "apps" in the namespace "default"
  	* Error during rollback: resource name may not be empty
  
```

Much better! Now instead of an EOF, they see the underlying error.
