### PR TITLE
Terminal: Auto wrap overflow text in tables

### DIFF
--- a/terminal/glint.go
+++ b/terminal/glint.go
@@ -186,7 +186,7 @@ func (ui *glintUI) Table(tbl *Table, opts ...Option) {
 	table := tablewriter.NewWriter(&buf)
 	table.SetHeader(tbl.Headers)
 	table.SetBorder(false)
-	table.SetAutoWrapText(false)
+	table.SetAutoWrapText(true)
 
 	if cfg.Style == "Simple" {
 		// Format the table without borders, simple output

--- a/terminal/noninteractive.go
+++ b/terminal/noninteractive.go
@@ -132,7 +132,7 @@ func (ui *nonInteractiveUI) Table(tbl *Table, opts ...Option) {
 	table := tablewriter.NewWriter(cfg.Writer)
 	table.SetHeader(tbl.Headers)
 	table.SetBorder(false)
-	table.SetAutoWrapText(false)
+	table.SetAutoWrapText(true)
 
 	if cfg.Style == "Simple" {
 		// Format the table without borders, simple output

--- a/terminal/table.go
+++ b/terminal/table.go
@@ -51,7 +51,7 @@ func (u *basicUI) Table(tbl *Table, opts ...Option) {
 
 	table.SetHeader(tbl.Headers)
 	table.SetBorder(false)
-	table.SetAutoWrapText(false)
+	table.SetAutoWrapText(true)
 
 	if cfg.Style == "Simple" {
 		// Format the table without borders, simple output


### PR DESCRIPTION
Prior to this commit, text would overflow into the next line, making it really difficult to read anything in a table. This commit fixes that by auto wrapping the text, which fits it inside the cell without overflowing the table.